### PR TITLE
Add .ipynb_checkpoints/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 notebooks/data
 notebooks/cifar_net.pth
+.ipynb_checkpoints/


### PR DESCRIPTION
I propose to add .ipynb_checkpoints/ to .gitignore because this folder is automatically created when working with notebooks with JupyterLab. 
It is more convenient to have it ignored by default.
Thanks!