### PR TITLE
Pin image version to `2.1.1`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/universal:2.1.1",
   "hostRequirements": {
     "cpus": 4
   },


### PR DESCRIPTION
In the latest version of the `devcontainers/universal` image, the Jupyter server package had a major version bump to `2.0.1` which changes the output of some of the commands. At the moment, this means users will not be able to connect to JupyterLab if using a codespace. This can be reverted once the fixes have been deployed by the Codespaces team.