### PR TITLE
Revert image pinning to `2.1.1`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2.1.1",
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
   "hostRequirements": {
     "cpus": 4
   },


### PR DESCRIPTION
Reverts https://github.com/github/codespaces-jupyter/pull/13

We should merge this PR once the Codespaces team releases a fix for `jupyter_server` v2.