### PR TITLE
Remove existing cache when creating codespace to save space in template

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,7 @@
     "cpus": 4
   },
   "waitFor": "onCreateCommand",
+  "initializeCommand": "docker system prune -af",
   "updateContentCommand": "python3 -m pip install -r requirements.txt",
   "postCreateCommand": "",
   "customizations": {


### PR DESCRIPTION
This is a temporary fix that should be reverted when subsequent fixes are deployed by the Codespaces team.