### PR TITLE
Remove temporary initializeCommand

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,6 @@
     "cpus": 4
   },
   "waitFor": "onCreateCommand",
-  "initializeCommand": "docker system prune -af",
   "updateContentCommand": "python3 -m pip install -r requirements.txt",
   "postCreateCommand": "",
   "customizations": {


### PR DESCRIPTION
This was needed as a temporary fix to allow Codespace templates to be created with this repo. Now that a more permanent solution has been implemented upstream, this can be removed.