### PR TITLE
Pin notebook requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 ipywidgets==7.7.1
-matplotlib
-numpy
-pandas
-torch
+matplotlib==3.7.0
+numpy==1.24.2
+pandas==1.5.3
+torch==1.12.1
 torchvision==0.13.1
 tqdm==4.64.0


### PR DESCRIPTION
This PR pins our notebooks' requirements in order to avoid trouble down the road. Without this change, any major update to `matplotlib`, `numpy`, `pandas`, or `torch` could break our notebooks.