### PR TITLE
Revert "Bump torch from 1.12.1 to 1.13.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ ipywidgets==7.7.1
 matplotlib==3.7.0
 numpy==1.24.2
 pandas==1.5.3
-torch==1.13.1
+torch==1.12.1
 torchvision==0.13.1
 tqdm==4.64.0


### PR DESCRIPTION
Reverts github/codespaces-jupyter#37

Looks like this conflicts with `torchvision`: https://github.com/github/codespaces-jupyter/actions/runs/4204157891/jobs/7294451146