### PR TITLE
Revert "Bump torch from 1.12.1 to 1.13.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ ipywidgets==7.7.1
 matplotlib==3.7.0
 numpy==1.24.2
 pandas==1.5.3
-torch==1.13.1
+torch==1.12.1
 torchvision==0.13.1
 tqdm==4.64.0


### PR DESCRIPTION
Reverts github/codespaces-jupyter#482

This PR broke prebuild template creation:

```
INFO: pip is looking at multiple versions of torchvision to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r requirements.txt (line 6) and torch==1.13.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested torch==1.13.1
    torchvision 0.13.1 depends on torch==1.12.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
updateContentCommand failed with exit code 1. Skipping any further user-provided commands.

Error: Command failed: /bin/sh -c python3 -m pip install -r requirements.txt
    at OY (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:235:130)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Nl (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:227:4393)
{"outcome":"error","message":"Command failed: /bin/sh -c python3 -m pip install -r requirements.txt","description":"The updateContentCommand in the devcontainer.json failed.","containerId":"8b2a964d076b7c1877989969d778ddd24d63000fffaab4e7a7e892f911cce9ac"}
    at async Rl (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:227:3738)
    at async Ml (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:227:2814)
    at async Js (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:227:2386)
    at async aAA (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:462:1346)
    at async SK (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:462:964)
devcontainer process exited with exit code 1
    at async SAA (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:479:3660)
    at async GC (/usr/lib/node_modules/@devcontainers/cli/dist/spec-node/devContainersSpecCLI.js:479:4775)
Error code: 1309 (UnifiedContainersErrorPrebuilTemplateOnCreateOrUpdateContentFailed)
Container creation failed.
Jobs failed, exiting the agent. Error code: 1309 (UnifiedContainersErrorPrebuilTemplateOnCreateOrUpdateContentFailed)
Error: Process completed with exit code 1.
```