### PR TITLE
Update torch to 2.8.0 and torchvision to 0.23.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 ipywidgets==8.1.2
 matplotlib==3.8.4
 pandas==2.2.2
-torch==2.7.1
-torchvision==0.21.0
+torch==2.8.0
+torchvision==0.23.0
 tqdm==4.66.4


### PR DESCRIPTION
This PR updates the PyTorch dependencies to resolve compatibility issues:

### Changes Made
- **torch**: `2.7.1` → `2.8.0`
- **torchvision**: `0.21.0` → `0.23.0`

The previous CI failures were caused by dependency conflicts where:
- Dependabot tried to update `torch` to `2.8.0`
- But `torchvision==0.21.0` specifically requires `torch==2.6.0`
- This caused pip dependency resolution to fail

### Solution
Updated `torchvision` to version `0.23.0`, which is compatible with `torch==2.8.0`.