### PR TITLE
Fix memory leak in Jupyter notebooks

### DIFF
--- a/notebooks/image-classifier.ipynb
+++ b/notebooks/image-classifier.ipynb
@@ -89,7 +89,8 @@
     "    plt.title(classes[labels[i]])\n",
     "\n",
     "plt.suptitle('Preview of Training Data', size=20)\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close()"
    ]
   },
   {
@@ -255,7 +256,8 @@
     "    plt.title(label, color=color)\n",
     "\n",
     "plt.suptitle('Objects Found by Model', size=20)\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close()"
    ]
   },
   {

--- a/notebooks/matplotlib.ipynb
+++ b/notebooks/matplotlib.ipynb
@@ -47,7 +47,8 @@
     "import matplotlib.pyplot as plt\n",
     "plt.plot([1, 2, 3, 4, 5])\n",
     "plt.ylabel('Numbers')\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close()"
    ]
   },
   {
@@ -77,7 +78,8 @@
    ],
    "source": [
     "plt.plot([1, 2, 3, 4], [1, 4, 9, 16])\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close()"
    ]
   },
   {
@@ -108,7 +110,8 @@
    "source": [
     "plt.plot([1, 2, 3, 4], [1, 4, 9, 16], 'ro')\n",
     "plt.axis([0, 6, 0, 20])\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close()"
    ]
   },
   {
@@ -144,7 +147,8 @@
     "\n",
     "# red dashes, blue squares and green triangles\n",
     "plt.plot(t, t, 'r--', t, t**2, 'bs', t, t**3, 'g^')\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close()"
    ]
   },
   {
@@ -184,7 +188,8 @@
     "plt.scatter('a', 'b', c='c', s='d', data=data)\n",
     "plt.xlabel('entry a')\n",
     "plt.ylabel('entry b')\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close()"
    ]
   },
   {
@@ -225,7 +230,8 @@
     "plt.subplot(133)\n",
     "plt.plot(names, values)\n",
     "plt.suptitle('Categorical Plotting')\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close()"
    ]
   }
  ],

--- a/notebooks/population.ipynb
+++ b/notebooks/population.ipynb
@@ -37,7 +37,8 @@
     "plt.title(\"Population of Atlantis\")\n",
     "plt.xlabel('Year')\n",
     "plt.ylabel('Population')\n",
-    "plt.show()"
+    "plt.show()\n",
+    "plt.close()"
    ]
   }
  ],


### PR DESCRIPTION
This change addresses a memory leak in several Jupyter notebooks caused by not closing Matplotlib plots after they are displayed.

The fix adds `plt.close()` after each `plt.show()` call in the following notebooks:
- `notebooks/image-classifier.ipynb`
- `notebooks/matplotlib.ipynb`
- `notebooks/population.ipynb`

This ensures that the memory used by the plot figures is released, preventing memory leaks, especially in long-running sessions or when generating multiple plots.