### PR TITLE
chore: upgrade dependencies and devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "image": "mcr.microsoft.com/devcontainers/universal:6",
   "hostRequirements": {
     "cpus": 4
   },

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 ipywidgets==8.1.8
-matplotlib==3.8.4
-pandas==2.2.2
-torch==2.8.0
-torchvision==0.23.0
-tqdm==4.66.4
+matplotlib==3.10.8
+pandas==3.0.2
+torch==2.10.0
+torchvision==0.25.0
+tqdm==4.67.2
 pillow>=12.1.1
 fonttools>=4.60.0
 filelock>=3.20.3


### PR DESCRIPTION
## Changes

- Upgrade devcontainer image from `universal:2` to `universal:6`
- Update dependencies:
  - matplotlib 3.8.4 → 3.10.8
  - pandas 2.2.2 → 3.0.2
  - torch 2.8.0 → 2.10.0
  - torchvision 0.23.0 → 0.25.0
  - tqdm 4.66.4 → 4.67.2

## Testing

Tested in Codespace environment—all changes work fine.