### PR TITLE
Update PyTorch dependencies

### DIFF
--- a/notebooks/image-classifier.ipynb
+++ b/notebooks/image-classifier.ipynb
@@ -28,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -74,7 +74,7 @@
     "\n",
     "# Grab images from our training data\n",
     "dataiter = iter(trainloader)\n",
-    "images, labels = dataiter.next()\n",
+    "images, labels = next(dataiter)\n",
     "\n",
     "for i in range(batch_size):\n",
     "    # Add new subplot\n",
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -226,7 +226,7 @@
     "# Pick random photos from training set\n",
     "if dataiter == None:\n",
     "    dataiter = iter(testloader)\n",
-    "images, labels = dataiter.next()\n",
+    "images, labels = next(dataiter)\n",
     "\n",
     "# Load our model\n",
     "net = Net()\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 ipywidgets==8.1.8
 matplotlib==3.8.4
 pandas==2.2.2
-torch==2.10.0
-torchvision==0.25.0
+torch==2.13.0
+torchvision==0.28.0
 tqdm==4.66.4
 pillow>=12.1.1
 fonttools>=4.60.0


### PR DESCRIPTION
**Summary**

- Upgrade PyTorch from 2.10.0 to patched version 2.13.0
- Upgrade torchvision from 0.25.0 to compatible version 0.28.0
- Replace unsupported dataiter.next() calls with next(dataiter)

**Validation**

- Verified iterator behavior on both PyTorch versions
- Compiled all notebook code cells
- Ran pip check successfully
- Confirmed DataLoader iteration with PyTorch 2.13.0